### PR TITLE
ci: deploy copyright-check v0.2.0

### DIFF
--- a/.github/workflows/_shared-copyright-check.yml
+++ b/.github/workflows/_shared-copyright-check.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install copyright-check
-        run: pip install https://github.com/eclipse-kura/copyright-check/releases/download/0.1.0/copyright_check-0.1.0-py3-none-any.whl
+        run: pip install https://github.com/eclipse-kura/copyright-check/releases/download/0.2.0/copyright_check-0.2.0-py3-none-any.whl
 
       - name: Run check
         run: copyright-check -c ${{ inputs.config-path }} $(git diff --name-only HEAD^1 HEAD)


### PR DESCRIPTION
This PR updates the `copyright-check` workflow to use the updated version of the `copyright-check` tool. See: https://github.com/eclipse-kura/copyright-check/releases/tag/0.2.0