### PR TITLE
feat(workflows): add BOM POM SBOM scan

### DIFF
--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -100,12 +100,12 @@ jobs:
           name: "${{ steps.info.outputs.project_name }}-sbom"
           path: "./${{ steps.info.outputs.project_name }}-bom/bom.json"
 
-  store-sbom-data:
-    needs: ['generate-sbom']
-    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
-    with:
-      projectName: ${{ needs.generate-sbom.outputs.project-name }}
-      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
-      bomArtifact: "${{ needs.generate-sbom.outputs.project-name }}-sbom"
-      bomFilename: 'bom.json'
-      parentProject: ${{ inputs.dependency-track-id }}
+#   store-sbom-data:
+#     needs: ['generate-sbom']
+#     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+#     with:
+#       projectName: ${{ needs.generate-sbom.outputs.project-name }}
+#       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+#       bomArtifact: "${{ needs.generate-sbom.outputs.project-name }}-sbom"
+#       bomFilename: 'bom.json'
+#       parentProject: ${{ inputs.dependency-track-id }}

--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -100,12 +100,12 @@ jobs:
           name: "${{ steps.info.outputs.project_name }}-sbom"
           path: "./${{ steps.info.outputs.project_name }}-bom/target/bom.json"
 
-#   store-sbom-data:
-#     needs: ['generate-sbom']
-#     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
-#     with:
-#       projectName: ${{ needs.generate-sbom.outputs.project-name }}
-#       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
-#       bomArtifact: "${{ needs.generate-sbom.outputs.project-name }}-sbom"
-#       bomFilename: 'bom.json'
-#       parentProject: ${{ inputs.dependency-track-id }}
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: ${{ needs.generate-sbom.outputs.project-name }}
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: "${{ needs.generate-sbom.outputs.project-name }}-sbom"
+      bomFilename: 'bom.json'
+      parentProject: ${{ inputs.dependency-track-id }}

--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: "${{ steps.info.outputs.project_name }}-sbom"
-          path: "./${{ steps.info.outputs.project_name }}-bom/bom.json"
+          path: "./${{ steps.info.outputs.project_name }}-bom/target/bom.json"
 
 #   store-sbom-data:
 #     needs: ['generate-sbom']

--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -11,7 +11,7 @@ env:
   JAVA_VERSION: '17' # java version used by the product
   JAVA_DISTRO: 'temurin' # java distro used by the product
   PLUGIN_VERSION: '2.7.8' # cyclonedx-maven-plugin version to use
-  SBOM_TYPE: 'makeBom>' # cyclonedx plugin goal
+  SBOM_TYPE: 'makeBom' # cyclonedx plugin goal
   WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
   INPUT_TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
   EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -1,0 +1,111 @@
+name: "Kura SBOM scan via cyclonedx (shared)"
+
+on:
+  workflow_call:
+    inputs:
+      dependency-track-id:
+        required: true
+        type: string
+
+env:
+  JAVA_VERSION: '17' # java version used by the product
+  JAVA_DISTRO: 'temurin' # java distro used by the product
+  PLUGIN_VERSION: '2.7.8' # cyclonedx-maven-plugin version to use
+  SBOM_TYPE: 'makeBom>' # cyclonedx plugin goal
+  WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  INPUT_TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
+  EVENT_NAME: ${{ github.event_name }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-22.04
+    outputs:
+      project-name: ${{ steps.info.outputs.project_name }}
+      project-version: ${{ steps.info.outputs.project_version }}
+    steps:
+      - name: Set checkout ref
+        id: set-checkout-ref
+        shell: bash
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            echo "CHECKOUT_REF=$WORKFLOW_HEAD_BRANCH" >> $GITHUB_ENV
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "CHECKOUT_REF=$INPUT_TARGET_BRANCH" >> $GITHUB_ENV
+          else
+            echo "CHECKOUT_REF=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Debug branch information
+        run: |
+          echo "=== Debug Branch Information ==="
+          echo "Event name: $EVENT_NAME"
+          echo "Current branch (git): $(git branch --show-current)"
+          echo "==============================="
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Extract project info
+        id: info
+        shell: bash
+        run: |
+          project_name=$(\
+            mvn --file ./pom.xml \
+              -Dexec.executable=echo \
+              -Dexec.args='${project.artifactId}' \
+              --quiet exec:exec \
+              --non-recursive \
+          )
+
+          resolved_version=$(\
+            mvn --file ./pom.xml \
+              -Dexec.executable=echo \
+              -Dexec.args='${project.version}' \
+              --quiet exec:exec \
+              --non-recursive \
+          )
+
+          # Substitute "-SNAPSHOT" suffix with "@dev" if present
+          version="${resolved_version/-SNAPSHOT/@dev}"
+
+          # Set the output values
+          echo "project_name=$project_name" >> $GITHUB_OUTPUT
+          echo "resolved_version=$resolved_version" >> $GITHUB_OUTPUT
+          echo "project_version=$version" >> $GITHUB_OUTPUT
+
+          echo "=== Debug Project Information ==="
+          echo "Project name: $project_name"
+          echo "Resolved version: $resolved_version"
+          echo "Project version: $version"
+          echo "==============================="
+
+      - name: Generate sbom
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "${{ steps.info.outputs.project_name }}-bom/pom.xml"
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: "${{ steps.info.outputs.project_name }}-sbom"
+          path: "./${{ steps.info.outputs.project_name }}-bom/bom.json"
+
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: ${{ needs.generate-sbom.outputs.project-name }}
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: "${{ needs.generate-sbom.outputs.project-name }}-sbom"
+      bomFilename: 'bom.json'
+      parentProject: ${{ inputs.dependency-track-id }}

--- a/samples/sbom.yml
+++ b/samples/sbom.yml
@@ -21,7 +21,12 @@ permissions:
 
 jobs:
   call-workflow-in-public-repo:
-    uses: eclipse-kura/.github/.github/workflows/_shared-sbom-cdxgen.yml@main
+    # For repositories using the BOM POM use cyclonedx-based SBOM generation workflow
+    # Note: the workflow expects the BOM POM to be stored in a folder named "<project-name>-bom"
+    uses: eclipse-kura/.github/.github/workflows/_shared-sbom-cyclonedx.yml@main
+    # For repositories still using the `lib/` folders to store their external dependencies
+    # use the cdxgen-based SBOM generation workflow
+    # uses: eclipse-kura/.github/.github/workflows/_shared-sbom-cdxgen.yml@main
     with:
       # The parent project UUID the uploaded SBOM should be associated with.
       # Refer to https://sbom.eclipse.org/ to retrieve the UUID.


### PR DESCRIPTION
Given our switch to BOM POMs for Kura addons we needed a new action to generate the SBOM leveraging the BOM POM. This PR introduces the new action following the [Eclipse Foundation example](https://eclipse-csi.github.io/security-handbook/sbom/howto.html#example-workflow-maven).

Tested working on `kura-artemis`.

**Note**:  the workflow expects the BOM POM to be stored in a folder named `<artifactId>-bom`. Example [`kura-artemis-bom`](https://github.com/eclipse-kura/kura-artemis/tree/develop/kura-artemis-bom).
