### PR TITLE
fix(workflows): CycloneDX based SBOM generation requires project build

### DIFF
--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -56,6 +56,10 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
 
+      - name: Build project
+        run: |
+          mvn clean install -Dmaven.test.skip=true
+
       - name: Extract project info
         id: info
         shell: bash


### PR DESCRIPTION
`kura-bluetooth` and `kura-position` SBOM generation fails if the project is not built. This PR fixes the issue.