### PR TITLE
fix(workflows): cyclonedx-maven-plugin 2.7.8 -> 2.9.1

### DIFF
--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Generate sbom
         run: |
-          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "${{ steps.info.outputs.project_name }}-bom/pom.xml"
+          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "${{ steps.info.outputs.project_name }}-bom/pom.xml" -DprojectType=framework
 
       - name: Upload sbom
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0


### PR DESCRIPTION
This pull request updates the shared CycloneDX SBOM workflow to use a newer plugin version and adds a configuration option to better specify the project type during SBOM generation.

Dependency update:

* Updated the CycloneDX Maven plugin version from `2.7.8` to `2.9.1` in `.github/workflows/_shared-sbom-cyclonedx.yml` to fix current build failures in `kura-position` and `kura-wires`
* Added the `-DprojectType=framework` option to the Maven command in the SBOM generation step, which helps clarify the nature of the project for the SBOM output.