### PR TITLE
fix(workflows): revert CycloneDX based SBOM generation requires project build (#15)

### DIFF
--- a/.github/workflows/_shared-sbom-cyclonedx.yml
+++ b/.github/workflows/_shared-sbom-cyclonedx.yml
@@ -56,10 +56,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
 
-      - name: Build project
-        run: |
-          mvn clean install -Dmaven.test.skip=true
-
       - name: Extract project info
         id: info
         shell: bash


### PR DESCRIPTION
This reverts commit dbc48ae9d7c4423356473186f150077f0d93dc3d.

Thanks to #16 it looks like we don't need to build the project before generating the SBOM. This change will reduce our Github Action usage.
