### PR TITLE
fix: remove permissions

### DIFF
--- a/.github/workflows/_shared-pr-lint.yml
+++ b/.github/workflows/_shared-pr-lint.yml
@@ -2,11 +2,6 @@ name: "Lint PR (shared)"
 
 on: workflow_call
 
-permissions:
-  contents: read
-  pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
-  statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
-
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
Fix error:

```
[Invalid workflow file: .github/workflows/semantic-pr.yml#L14](https://github.com/eclipse-kura/kura/actions/runs/24242735961/workflow)
The workflow is not valid. .github/workflows/semantic-pr.yml (Line: 14, Col: 3): Error calling workflow 'eclipse-kura/.github/.github/workflows/_shared-pr-lint.yml@main'. The workflow is requesting 'contents: read, statuses: write', but is only allowed 'contents: none, statuses: none'.
```

See: https://github.com/eclipse-kura/kura/actions/runs/24242735961